### PR TITLE
Use CARTO english map tiles (#96)

### DIFF
--- a/templates/gazetteer/gazetteer_index.html
+++ b/templates/gazetteer/gazetteer_index.html
@@ -51,9 +51,9 @@
 
             <script>
                 const map = L.map('map').setView([41.163, 28.766], 3);
-                L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-                    attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap contributors</a>',
-                    maxZoom: 18,
+                L.tileLayer('https://{s}.basemaps.cartocdn.com/rastertiles/voyager_labels_under/{z}/{x}/{y}{r}.png', {
+                    attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>',
+                    maxZoom: 20
                 }).addTo(map);
 
     // Store markers in a Map object for easy lookup

--- a/templates/gazetteer/gazetteer_single.html
+++ b/templates/gazetteer/gazetteer_single.html
@@ -143,9 +143,9 @@
                 let map = L.map('map').setView([latitude, longitude], 6);
 
             // Add an OpenStreetMap tile layer
-                L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-                    attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap contributors</a>',
-                    maxZoom: 18,
+                L.tileLayer('https://{s}.basemaps.cartocdn.com/rastertiles/voyager_labels_under/{z}/{x}/{y}{r}.png', {
+                    attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>',
+                    maxZoom: 20
                 }).addTo(map);
 
             // Add a marker at the given location


### PR DESCRIPTION
### In this PR

Per #96:

- Use a base map from CARTO for tile layer so that labels are all in English