### PR TITLE
Sticky header on edition page (#97)

### DIFF
--- a/templates/stanzas.html
+++ b/templates/stanzas.html
@@ -270,7 +270,7 @@
               data-manifest-url="{{ manuscript.iiif_url }}">
             <div class="sticky pt-8 top-11">
               <div class="bg-white rounded-lg shadow-lg">
-                <div id="tify-container" class="w-full h-[calc(100vh-4rem)]"></div>
+                <div id="tify-container" class="w-full h-[calc(100vh-4.5rem)]"></div>
               </div>
             </div>
           </div>

--- a/templates/stanzas.html
+++ b/templates/stanzas.html
@@ -77,9 +77,9 @@
 
 {% block content %}
   <div class="mx-auto">
-    <section class="w-full p-4 my-10">
+    <section class="w-full p-4 mt-7 mb-10">
     <!-- Title and Hamburger Menu -->
-      <div class="flex justify-between items-center pb-8">
+      <div class="sticky top-0 bg-white z-10 flex justify-between items-center mb-5 shadow-md shadow-white py-3">
         <h3 class="text-4xl font-bold" id="top">
           "The Globe" (<em>La sfera</em>) by Gregorio Dati
         </h3>
@@ -268,9 +268,9 @@
               x-data="tifyViewer"
               data-has-known-folios="{{ has_known_folios|lower }}"
               data-manifest-url="{{ manuscript.iiif_url }}">
-            <div class="sticky pt-8 top-0">
+            <div class="sticky pt-8 top-11">
               <div class="bg-white rounded-lg shadow-lg">
-                <div id="tify-container" class="w-full h-screen"></div>
+                <div id="tify-container" class="w-full h-[calc(100vh-4rem)]"></div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
### In this PR

Per #97:
- Make the title and options menu “sticky” so that they stay in view as a reader scrolls